### PR TITLE
propose simple cli info

### DIFF
--- a/guides/bt_dualboot.md
+++ b/guides/bt_dualboot.md
@@ -2,6 +2,16 @@
 
 This is adapted from [the ArchWiki](https://wiki.archlinux.org/index.php/Bluetooth#Dual_boot_pairing), so all credit goes to the Arch community.
 
+This guide describes concepts and steps for sync Bluetooth keys manually. At the same time multiple tools exist handling this issue. Checkout ["bluetooth dualboot" on github](https://github.com/search?q=bluetooth+dualboot&type=repositories). 
+
+For example simple cli
+
+```console
+$ sudo bt-dualboot --sync-all
+```
+
+Checkout the tool https://github.com/x2es/bt-dualboot and another [alternatives](https://github.com/x2es/bt-dualboot#alternatives).
+
 ## 1.0 Prerequisites
 
 Install **chntpw**, a registry editor. 


### PR DESCRIPTION
Info about user friendly tool and alternatives handling Bluetooth dual boot issue.

I think for most users it would be valuable to have simple tool to handle devices pairing fast by single command or without commands at all using background service.

I have implemented `bt-dualboot` tool with focus to rich [best user's experience](https://github.com/x2es/bt-dualboot/blob/master/README-dev.md#application-concept). Here is list of [key advantages](https://github.com/x2es/bt-dualboot#advantages-and-alternatives) comparing to another tools and approaches.

**Simplest usage way is**:

```console
$ sudo bt-dualboot --sync-all
```

**Advanced usage way** allows get list of devices and sync wanted devices:

```console
$ sudo bt-dualboot --list
....

$ sudo bt-dualboot --sync C2:9E:1D:E2:3D:A5
``` 

[usage details](https://github.com/x2es/bt-dualboot#usage-shortest-way)
[cli reference](https://github.com/x2es/bt-dualboot#cli-reference)